### PR TITLE
Use node cluster

### DIFF
--- a/node/main.js
+++ b/node/main.js
@@ -1,8 +1,21 @@
+var cluster = require('cluster');
 var http = require('http');
+var numCPUs = require('os').cpus().length;
 
-var server = http.createServer(function (req, res) {
+if (cluster.isMaster) {
+  // Fork workers.
+  for (var i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
+
+  cluster.on('exit', function(worker, code, signal) {
+    console.log('worker ' + worker.process.pid + ' died');
+  });
+} else {
+  // Workers can share any TCP connection
+  // In this case its a HTTP server
+  http.createServer(function(req, res) {
     res.writeHead(200, { "Content-Type": "text/plain" });
     res.end("ok");
-});
-
-server.listen(8080);
+  }).listen(8080);
+}


### PR DESCRIPTION
A single instance of Node runs in a single thread. To take advantage of multi-core systems the user will sometimes want to launch a cluster of Node processes to handle the load.
http://nodejs.org/api/cluster.html
